### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/patches/api/0118-RangedEntity-API.patch
+++ b/patches/api/0118-RangedEntity-API.patch
@@ -167,17 +167,15 @@ index b4343903b66a7fb5250c1da2e09c9e5863c20daf..aa88aede6c4e66a608a63d07bc66d603
 +public interface Witch extends Raider, RangedEntity { // Paper
  }
 diff --git a/src/main/java/org/bukkit/entity/Wither.java b/src/main/java/org/bukkit/entity/Wither.java
-index 3bc332ee7f7d428bef6e2566ddded8b941858e2e..426d3693317cd303d35d8203026b528d87e401d5 100644
+index 225c65a20a3e33dfb14e108a36f2f4bc60f7920c..b86f0196e6eb8070830f63a94f732522c2a6c2f1 100644
 --- a/src/main/java/org/bukkit/entity/Wither.java
 +++ b/src/main/java/org/bukkit/entity/Wither.java
-@@ -1,7 +1,9 @@
- package org.bukkit.entity;
- 
-+import com.destroystokyo.paper.entity.RangedEntity;
-+
+@@ -6,7 +6,7 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Represents a Wither boss
   */
 -public interface Wither extends Monster, Boss {
-+public interface Wither extends Monster, Boss, RangedEntity { // Paper
- }
++public interface Wither extends Monster, Boss, com.destroystokyo.paper.entity.RangedEntity { // Paper
+ 
+     /**
+      * {@inheritDoc}

--- a/patches/api/0312-Missing-Entity-Behavior-API.patch
+++ b/patches/api/0312-Missing-Entity-Behavior-API.patch
@@ -635,13 +635,14 @@ index 627e3c1a96ae3331f5aa2dd7803dd2a31c7204be..3c447d2300c866ae605eeca97bd869f4
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Wither.java b/src/main/java/org/bukkit/entity/Wither.java
-index 426d3693317cd303d35d8203026b528d87e401d5..8c95cd6933f11076de936854f379e6fc8600b525 100644
+index b86f0196e6eb8070830f63a94f732522c2a6c2f1..a1b42ae35dda2da90ba00a2d6666514f7c5b11dd 100644
 --- a/src/main/java/org/bukkit/entity/Wither.java
 +++ b/src/main/java/org/bukkit/entity/Wither.java
-@@ -6,4 +6,34 @@ import com.destroystokyo.paper.entity.RangedEntity;
-  * Represents a Wither boss
-  */
- public interface Wither extends Monster, Boss, RangedEntity { // Paper
+@@ -48,4 +48,35 @@ public interface Wither extends Monster, Boss, com.destroystokyo.paper.entity.Ra
+         LEFT,
+         RIGHT
+     }
++
 +    // Paper start
 +    /**
 +     * @return whether the wither is charged

--- a/patches/server/0008-Adventure.patch
+++ b/patches/server/0008-Adventure.patch
@@ -1163,7 +1163,7 @@ index 762a9392ffac3042356709dddd15bb3516048bed..3544e2dc2522e9d6305d727d56e73490
          buf.writeComponent(this.footer);
      }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 3700c14c8fe5a52ad6eb6d1ca58232beea16c2d7..a29450df13bc32d5bc700a944541793a696a94d2 100644
+index 3431a70a07c08fdc20c7a8d667e6275f212b549e..d4d444b5864073fe86bfc7b5a68344b5aae8c05f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -145,6 +145,7 @@ import net.minecraft.world.scores.Score;
@@ -1777,7 +1777,7 @@ index d29c6d0536619fab5a48fbb52115dac09e7d7ca3..75871f74a25ee34db89a431de584b998
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ee84148faf92daad40adbf90f89c5c19ea36ebcc..b889662e794cc4e00fae8a4ab5174af698fc0da2 100644
+index b8b47416b66ec2272ce9ffdc06b0a1dd91b4c05a..5476dc1e80093d7684bc238bae102cbb691cec4f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -143,6 +143,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -1788,7 +1788,7 @@ index ee84148faf92daad40adbf90f89c5c19ea36ebcc..b889662e794cc4e00fae8a4ab5174af6
  
      private static final Random rand = new Random();
  
-@@ -1862,4 +1863,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1863,4 +1864,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return this.spigot;
      }
      // Spigot end

--- a/patches/server/0039-Per-Player-View-Distance-API-placeholders.patch
+++ b/patches/server/0039-Per-Player-View-Distance-API-placeholders.patch
@@ -7,10 +7,10 @@ I hope to look at this more in-depth soon. It appears doable.
 However this should not block the update.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 1705a2bb3497546635a1b82dcd8d23cb87c21084..a2227d2b29f2f78d0b7fc8f0650f107b51ca97fc 100644
+index d184c3f8f8f86b783f17d71886c9b43a74482f2a..e8cda0032a6c80e939d24be190507cba006a0280 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2204,4 +2204,6 @@ public class ServerPlayer extends Player {
+@@ -2205,4 +2205,6 @@ public class ServerPlayer extends Player {
          return (CraftPlayer) super.getBukkitEntity();
      }
      // CraftBukkit end
@@ -18,10 +18,10 @@ index 1705a2bb3497546635a1b82dcd8d23cb87c21084..a2227d2b29f2f78d0b7fc8f0650f107b
 +    public final int getViewDistance() { return this.getLevel().getChunkSource().chunkMap.viewDistance - 1; } // Paper - placeholder
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b889662e794cc4e00fae8a4ab5174af698fc0da2..c36b862f4019d899c834177f42b1983818ab0138 100644
+index 5476dc1e80093d7684bc238bae102cbb691cec4f..be8b7170f3746e53985286066138781099930934 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1832,6 +1832,37 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1833,6 +1833,37 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return world.spigotConfig.simulationDistance;
      }
      // Spigot end

--- a/patches/server/0192-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/server/0192-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -34,10 +34,10 @@ index eb6981ca27d27946c748047660ced880c4dea01a..3cb4a84a08cbf76e39da5f25fea490c2
  
              if (this.sendParticles(entityplayer, force, d0, d1, d2, packetplayoutworldparticles)) { // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f1df6ac7bc8ceeb87bdee577132c4d07c9786d20..72c3ccc3d326aea029a3d4b5148496c0aa9ca8f9 100644
+index 982b6dabf2aa8ac79596a235ffff1be948492b72..4a83fa80d11a5ef840cd556f845b4de84b3ad5f1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1812,11 +1812,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1813,11 +1813,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {

--- a/patches/server/0209-Expand-Explosions-API.patch
+++ b/patches/server/0209-Expand-Explosions-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expand Explosions API
 Add Entity as a Source capability, and add more API choices, and on Location.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 72c3ccc3d326aea029a3d4b5148496c0aa9ca8f9..567a1f957d668c509efae001242b1808a3a488b2 100644
+index 4a83fa80d11a5ef840cd556f845b4de84b3ad5f1..ffcaf40f8e310ef4ed292dac673a4e1da6dff0ea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -706,6 +706,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -707,6 +707,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean createExplosion(double x, double y, double z, float power, boolean setFire, boolean breakBlocks, Entity source) {
          return !this.world.explode(source == null ? null : ((CraftEntity) source).getHandle(), x, y, z, power, setFire, breakBlocks ? Explosion.BlockInteraction.BREAK : Explosion.BlockInteraction.NONE).wasCanceled;
      }

--- a/patches/server/0211-RangedEntity-API.patch
+++ b/patches/server/0211-RangedEntity-API.patch
@@ -148,11 +148,11 @@ index 60e00e539d214eb8854a53364c92c3cf55ca1062..d4eeb071dbbfca3ecea256228853bcb5
          super(server, entity);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java
-index 54a7defa85542765f3dd0d7ccb770dafd9c7d484..640b0860fbe3412da32d03187e6f355ba8f099ea 100644
+index 5f78b7ac2313cb8fe9ce835c0317217810a6b023..e92355fa2042c4cf15354a11b7058cacbe996f0d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java
-@@ -7,7 +7,7 @@ import org.bukkit.craftbukkit.boss.CraftBossBar;
- import org.bukkit.entity.EntityType;
+@@ -10,7 +10,7 @@ import org.bukkit.entity.EntityType;
+ import org.bukkit.entity.LivingEntity;
  import org.bukkit.entity.Wither;
  
 -public class CraftWither extends CraftMonster implements Wither {

--- a/patches/server/0213-Implement-World.getEntity-UUID-API.patch
+++ b/patches/server/0213-Implement-World.getEntity-UUID-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement World.getEntity(UUID) API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 567a1f957d668c509efae001242b1808a3a488b2..264bc6a4765109a16cea6413abe9bf9185b7c041 100644
+index ffcaf40f8e310ef4ed292dac673a4e1da6dff0ea..b456bb99db2cd0e48e44796063dc7da7eee64451 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1040,6 +1040,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1041,6 +1041,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return list;
      }
  

--- a/patches/server/0251-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
+++ b/patches/server/0251-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Make CraftWorld#loadChunk(int, int, false) load unconverted
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 264bc6a4765109a16cea6413abe9bf9185b7c041..3bba44d111c366e3740439d0937cad81d843eaf9 100644
+index b456bb99db2cd0e48e44796063dc7da7eee64451..9ba1b86cb576ae4b1a01c53dac49b836f79c62ea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -382,7 +382,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -383,7 +383,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0252-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0252-Asynchronous-chunk-IO-and-loading.patch
@@ -3562,10 +3562,10 @@ index 4160a35ecfa1c28b88d6ebbfd14a0be1933e3b6d..3e08ff74979c78b27537403bbcaf1345
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 3bba44d111c366e3740439d0937cad81d843eaf9..d0e6ea5ec01b89ebb4b1e6d803624e723ece1f9d 100644
+index 9ba1b86cb576ae4b1a01c53dac49b836f79c62ea..3c4f06c9446dd769999e8f52bd43709cdd5cf9b0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1875,6 +1875,34 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1876,6 +1876,34 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public DragonBattle getEnderDragonBattle() {
          return (this.getHandle().dragonFight() == null) ? null : new CraftDragonBattle(this.getHandle().dragonFight());
      }

--- a/patches/server/0269-Add-sun-related-API.patch
+++ b/patches/server/0269-Add-sun-related-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index d0e6ea5ec01b89ebb4b1e6d803624e723ece1f9d..d9763271118ac44a6465464fb097503b86ce925e 100644
+index 3c4f06c9446dd769999e8f52bd43709cdd5cf9b0..6871ee1f69b2dced4874c0d28b27b6ba11ef1c9f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -682,6 +682,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -683,6 +683,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          }
      }
  

--- a/patches/server/0320-improve-CraftWorld-isChunkLoaded.patch
+++ b/patches/server/0320-improve-CraftWorld-isChunkLoaded.patch
@@ -9,10 +9,10 @@ waiting for the execution queue to get to our request; We can just query
 the chunk status and get a response now, vs having to wait
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 0d3cea84314d4aeddc36266789283695d70f2eb7..536f6ff1d457b84a6f2a593c01f2760c55d59e33 100644
+index 7540be1005db97a20d44d55c0e59547113d6ad80..c7e919516254eabd21dc460be4569c44d1fe1176 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -287,13 +287,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -288,13 +288,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean isChunkLoaded(int x, int z) {

--- a/patches/server/0322-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/patches/server/0322-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -217,10 +217,10 @@ index 1fdb4242784e55d5bb6102deb150a57a156aacd3..419e1c4db73631de3d65d8a0e7d5eb08
          this.maxCount = i * i;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 536f6ff1d457b84a6f2a593c01f2760c55d59e33..a3fab58688c50c5ed325075c0deebd93f33d71d5 100644
+index c7e919516254eabd21dc460be4569c44d1fe1176..f782147a7523b952b272ba67c7b85164236379ef 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1349,15 +1349,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1350,15 +1350,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setKeepSpawnInMemory(boolean keepLoaded) {

--- a/patches/server/0327-Fix-World-isChunkGenerated-calls.patch
+++ b/patches/server/0327-Fix-World-isChunkGenerated-calls.patch
@@ -188,7 +188,7 @@ index a1bfcdd713c47d8613eb4af7625a64d51161690b..4bc33c31d497aa7d69226ab870fd7890
              } catch (Throwable throwable) {
                  if (dataoutputstream != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index a3fab58688c50c5ed325075c0deebd93f33d71d5..4eb2ef0e5e8f7f1962ef9e3020daa77b7be25309 100644
+index f782147a7523b952b272ba67c7b85164236379ef..0edb08a391f806e56ed1bd4812eb9c9d2b966bd7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -20,6 +20,7 @@ import java.util.Objects;
@@ -199,7 +199,7 @@ index a3fab58688c50c5ed325075c0deebd93f33d71d5..4eb2ef0e5e8f7f1962ef9e3020daa77b
  import java.util.function.Predicate;
  import java.util.stream.Collectors;
  import net.minecraft.core.BlockPos;
-@@ -292,8 +293,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -293,8 +294,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean isChunkGenerated(int x, int z) {
@@ -223,7 +223,7 @@ index a3fab58688c50c5ed325075c0deebd93f33d71d5..4eb2ef0e5e8f7f1962ef9e3020daa77b
          } catch (IOException ex) {
              throw new RuntimeException(ex);
          }
-@@ -405,20 +420,48 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -406,20 +421,48 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0450-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0450-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -44,10 +44,10 @@ index d4d8eee914f71d9a33feda82ef54cb0c40b0e60c..28a04d21801a9bb1e4311e6da28eae26
          this.printSaveWarning = false;
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 4eb2ef0e5e8f7f1962ef9e3020daa77b7be25309..d49a8e22dcee95a6e8a6a7fe45e46feae414515d 100644
+index 0edb08a391f806e56ed1bd4812eb9c9d2b966bd7..b50a05ada2e759cfdeb2af036337bf5ed5b60b7d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -276,8 +276,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -277,8 +277,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public Chunk getChunkAt(int x, int z) {
@@ -70,7 +70,7 @@ index 4eb2ef0e5e8f7f1962ef9e3020daa77b7be25309..d49a8e22dcee95a6e8a6a7fe45e46fea
  
      @Override
      public Chunk getChunkAt(Block block) {
-@@ -344,7 +357,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -345,7 +358,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean unloadChunkRequest(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk unload"); // Spigot
          if (this.isChunkLoaded(x, z)) {
@@ -79,7 +79,7 @@ index 4eb2ef0e5e8f7f1962ef9e3020daa77b7be25309..d49a8e22dcee95a6e8a6a7fe45e46fea
          }
  
          return true;
-@@ -422,9 +435,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -423,9 +436,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot
          // Paper start - Optimize this method
          ChunkPos chunkPos = new ChunkPos(x, z);
@@ -93,7 +93,7 @@ index 4eb2ef0e5e8f7f1962ef9e3020daa77b7be25309..d49a8e22dcee95a6e8a6a7fe45e46fea
              if (immediate == null) {
                  immediate = world.getChunkSource().chunkMap.getUnloadingChunk(x, z);
              }
-@@ -432,7 +448,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -433,7 +449,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
                  if (!(immediate instanceof ImposterProtoChunk) && !(immediate instanceof net.minecraft.world.level.chunk.LevelChunk)) {
                      return false; // not full status
                  }
@@ -102,7 +102,7 @@ index 4eb2ef0e5e8f7f1962ef9e3020daa77b7be25309..d49a8e22dcee95a6e8a6a7fe45e46fea
                  world.getChunk(x, z); // make sure we're at ticket level 32 or lower
                  return true;
              }
-@@ -458,7 +474,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -459,7 +475,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              // we do this so we do not re-read the chunk data on disk
          }
  
@@ -111,7 +111,7 @@ index 4eb2ef0e5e8f7f1962ef9e3020daa77b7be25309..d49a8e22dcee95a6e8a6a7fe45e46fea
          world.getChunkSource().getChunk(x, z, ChunkStatus.FULL, true);
          return true;
          // Paper end
-@@ -1978,6 +1994,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1979,6 +1995,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          return this.world.getChunkSource().getChunkAtAsynchronously(x, z, gen, urgent).thenComposeAsync((either) -> {
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);

--- a/patches/server/0465-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0465-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -796,7 +796,7 @@ index 9079e469161098e1520f6b9fd963adedd500024b..d0170f92335b331d6904e8c27e75f97e
          boolean flag1 = this.chunkMap.promoteChunkMap();
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 30e82817418ebe7e61eab3ed290ce938dde42297..1ab42e2b35014ad941d97ffef5706e380418bc8f 100644
+index 0a2c94e289dd0dac88a38516a9be09a03acfc579..c363b5f48253cd77c6b986b85f068a38df5319b8 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -185,6 +185,7 @@ public class ServerPlayer extends Player {
@@ -1148,7 +1148,7 @@ index ba0f9d729a4d4bd35050ab41d6d70ee3ea46beeb..3c3960abd63297bf6c247bc48de3b77a
      public float yRotO;
      public float xRotO;
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 47257e22c75acf7f8eb582d7bbee5e8a6af9b4a6..b3752e1f1ed310cb104c8f955a94baf787a9e9ac 100644
+index b9ad77606d88d7ca41c0070063b8599ecc048422..0388b89a5f67ebaf344de53464922daddd234199 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -141,7 +141,7 @@ public class LevelChunk extends ChunkAccess {
@@ -1177,10 +1177,10 @@ index 47257e22c75acf7f8eb582d7bbee5e8a6af9b4a6..b3752e1f1ed310cb104c8f955a94baf7
          org.bukkit.event.world.ChunkUnloadEvent unloadEvent = new org.bukkit.event.world.ChunkUnloadEvent(this.bukkitChunk, this.isUnsaved());
          server.getPluginManager().callEvent(unloadEvent);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index d49a8e22dcee95a6e8a6a7fe45e46feae414515d..1d2cfef57fd4eb53c707a76f612cee73ddfb3812 100644
+index b50a05ada2e759cfdeb2af036337bf5ed5b60b7d..03d2ff6e1595453d57b42da1b508da813f73b2bf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1992,6 +1992,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1993,6 +1993,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              return future;
          }
  

--- a/patches/server/0475-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
+++ b/patches/server/0475-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing strikeLighting call to
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 1d2cfef57fd4eb53c707a76f612cee73ddfb3812..37e646bc226d4da54c3b17be101bf50e6b7f362f 100644
+index 03d2ff6e1595453d57b42da1b508da813f73b2bf..e9353aa51d24e06c3bd67417215cdfb0c97a6d60 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2087,6 +2087,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2088,6 +2088,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              lightning.moveTo( loc.getX(), loc.getY(), loc.getZ() );
              lightning.visualOnly = true;
              lightning.isSilent = isSilent;

--- a/patches/server/0483-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
+++ b/patches/server/0483-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
@@ -17,10 +17,10 @@ index 38af4d10e2e09c0917ae8ff265e5a6c610fa4404..2cb1bad01d48efe0e7474ca8308d0d7e
              // if this keepSpawnInMemory is false a plugin has already removed our tickets, do not re-add
              this.removeTicketsForSpawn(this.paperConfig.keepLoadedRange, prevSpawn);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 37e646bc226d4da54c3b17be101bf50e6b7f362f..797dfc6b10aab7a84a19cd49854b23bd04341d6b 100644
+index e9353aa51d24e06c3bd67417215cdfb0c97a6d60..3fb6aabf79cdc9db86ecff56541ae7aa8a90e81d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -257,11 +257,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -258,11 +258,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean setSpawnLocation(int x, int y, int z, float angle) {
          try {
              Location previousLocation = this.getSpawnLocation();

--- a/patches/server/0529-Expose-world-spawn-angle.patch
+++ b/patches/server/0529-Expose-world-spawn-angle.patch
@@ -17,16 +17,3 @@ index 0b4d5ab836e861ea87bb72185a513bdf341d5921..30f0b20924d6b778e49761a72b50263c
              }
  
              Player respawnPlayer = entityplayer1.getBukkitEntity();
-diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 2a388f8bbbdfb4dc469bcfce6a6241066a7fe597..9c3e6e42c7906bd9270ec01c4ce8a693d799c0ff 100644
---- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-+++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -248,7 +248,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
-     @Override
-     public Location getSpawnLocation() {
-         BlockPos spawn = this.world.getSharedSpawnPos();
--        return new Location(this, spawn.getX(), spawn.getY(), spawn.getZ());
-+        return new Location(this, spawn.getX(), spawn.getY(), spawn.getZ(), world.levelData.getSpawnAngle(), 0.0F); // Paper - expose world spawn angle
-     }
- 
-     @Override

--- a/patches/server/0561-Added-WorldGameRuleChangeEvent.patch
+++ b/patches/server/0561-Added-WorldGameRuleChangeEvent.patch
@@ -64,10 +64,10 @@ index 74e10d581f8c1b0b026d8f940194971efbdef434..798afc145c54306fcf0838d8daef2bdf
  
          public int get() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9c3e6e42c7906bd9270ec01c4ce8a693d799c0ff..e9b23b3a0b512e8febbd0618c5ae86078deab38c 100644
+index 8a5bb077ffb2e88bea813fd89023f2d057526417..f56a0c203b7d459b7a59419d0cf8bc33002289f4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1797,8 +1797,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1798,8 +1798,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule)) return false;
  
@@ -82,7 +82,7 @@ index 9c3e6e42c7906bd9270ec01c4ce8a693d799c0ff..e9b23b3a0b512e8febbd0618c5ae8607
          handle.onChanged(this.getHandle().getServer());
          return true;
      }
-@@ -1833,8 +1838,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1834,8 +1839,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule.getName())) return false;
  

--- a/patches/server/0630-More-World-API.patch
+++ b/patches/server/0630-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index e9b23b3a0b512e8febbd0618c5ae86078deab38c..938e99d28b28ccd4273c9fddb1fd0d9b4210f28c 100644
+index f56a0c203b7d459b7a59419d0cf8bc33002289f4..f759c29be097095d757120528edb72f91ed7f054 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1966,6 +1966,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1967,6 +1967,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (nearest == null) ? null : new Location(this, nearest.getX(), nearest.getY(), nearest.getZ());
      }
  

--- a/patches/server/0656-Add-cause-to-Weather-ThunderChangeEvents.patch
+++ b/patches/server/0656-Add-cause-to-Weather-ThunderChangeEvents.patch
@@ -95,10 +95,10 @@ index 1bd338c7860adf3b846cd6caa33312b3269ac3ef..95635cc7367b757d149bb2c81326a041
              if (weather.isCancelled()) {
                  return;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 938e99d28b28ccd4273c9fddb1fd0d9b4210f28c..5e09816bf1aa9444df4d5480e37516623f8ce26c 100644
+index f759c29be097095d757120528edb72f91ed7f054..83e54e62d54e140cef5234396f40796b12ac8355 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1188,7 +1188,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1189,7 +1189,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setStorm(boolean hasStorm) {
@@ -107,7 +107,7 @@ index 938e99d28b28ccd4273c9fddb1fd0d9b4210f28c..5e09816bf1aa9444df4d5480e3751662
          this.setWeatherDuration(0); // Reset weather duration (legacy behaviour)
          this.setClearWeatherDuration(0); // Reset clear weather duration (reset "/weather clear" commands)
      }
-@@ -1210,7 +1210,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1211,7 +1211,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setThundering(boolean thundering) {

--- a/patches/server/0675-Missing-Entity-Behavior-API.patch
+++ b/patches/server/0675-Missing-Entity-Behavior-API.patch
@@ -564,12 +564,12 @@ index 2ba16e33dd21c3c72cb12244aa78c59bf53e76d1..634a5099fb6faea03615783f57e643ad
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java
-index 640b0860fbe3412da32d03187e6f355ba8f099ea..299d5e47489cfe489ac130a33a08cdb29ba76d72 100644
+index e92355fa2042c4cf15354a11b7058cacbe996f0d..4cf3a374c9ee7c7bcf82e778aa094eb4f8463595 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java
-@@ -38,4 +38,31 @@ public class CraftWither extends CraftMonster implements Wither, com.destroystok
-     public BossBar getBossBar() {
-         return this.bossBar;
+@@ -61,4 +61,31 @@ public class CraftWither extends CraftMonster implements Wither, com.destroystok
+         Entity target = this.getHandle().getLevel().getEntity(entityId);
+         return (target != null) ? (LivingEntity) target.getBukkitEntity() : null;
      }
 +
 +    // Paper start

--- a/patches/server/0711-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/server/0711-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -29,10 +29,10 @@ index 384222f321f1678803d62187b76bf3dee1970c0c..b10c0099ba0691cb167e78b8decafe39
                      blockposition1 = blockposition1.above(2);
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index abd119d2b018c5df0db6a85dbf4a36de897956e2..125e3b746663f3cfc4212a8b09e490c614320acc 100644
+index f30286bb421d7467304c7a8c506c458f14b65f14..f69882f1c90682566dc27653a6afcf67b2ed624b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -702,6 +702,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -703,6 +703,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (LightningStrike) lightning.getBukkitEntity();
      }
  

--- a/patches/server/0733-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0733-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -309,10 +309,10 @@ index 4fb0ad44672e0fed8c5d523d03801df725cc136f..7b1bccfbf44c5b431f52f4ed974f9143
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 125e3b746663f3cfc4212a8b09e490c614320acc..3c75f2a676c21941d21c3683e8ba4f51d880798b 100644
+index f69882f1c90682566dc27653a6afcf67b2ed624b..05352f89399d7c90ff029984889bddd73c31a7d1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1717,9 +1717,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1718,9 +1718,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(spawnCategory, "SpawnCategory cannot be null");
          Validate.isTrue(CraftSpawnCategory.isValidForLimits(spawnCategory), "SpawnCategory." + spawnCategory + " are not supported.");
  

--- a/patches/server/0742-Do-not-copy-visible-chunks.patch
+++ b/patches/server/0742-Do-not-copy-visible-chunks.patch
@@ -186,7 +186,7 @@ index ef28e0f57ba593265a3eca4d3f21d0b1b51e8740..f4c1316ae1cadc1a7a7fed16e0e99704
          while (objectbidirectionaliterator.hasNext()) {
              Entry<ChunkHolder> entry = (Entry) objectbidirectionaliterator.next();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 3c75f2a676c21941d21c3683e8ba4f51d880798b..760149102313626831e3692936c6a984f04d252a 100644
+index 05352f89399d7c90ff029984889bddd73c31a7d1..0ebacc6f35591b3f1fc740d484f30c7c2337392a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -161,7 +161,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -207,7 +207,7 @@ index 3c75f2a676c21941d21c3683e8ba4f51d880798b..760149102313626831e3692936c6a984
              if (chunkHolder.getTickingChunk() != null) {
                  ++ret;
              }
-@@ -355,7 +355,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -356,7 +356,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public Chunk[] getLoadedChunks() {
@@ -227,7 +227,7 @@ index 3c75f2a676c21941d21c3683e8ba4f51d880798b..760149102313626831e3692936c6a984
          return chunks.values().stream().map(ChunkHolder::getFullChunkNow).filter(Objects::nonNull).map(net.minecraft.world.level.chunk.LevelChunk::getBukkitChunk).toArray(Chunk[]::new);
      }
  
-@@ -431,7 +442,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -432,7 +443,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean refreshChunk(int x, int z) {

--- a/patches/server/0848-Implement-regenerateChunk.patch
+++ b/patches/server/0848-Implement-regenerateChunk.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Implement regenerateChunk
 Co-authored-by: Jason Penilla <11360596+jpenilla@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index fbfd094a938a96c03d614059fb1cd5a720865a83..8aaf12eb1b7c8fc996d2199d1182c04d28306817 100644
+index bd24cf74dfc0974f5bc132994deac45b4ec7b344..7b5e099f73dae3846a1190523e769530ffac2f28 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -133,6 +133,7 @@ import org.bukkit.util.Vector;
@@ -17,7 +17,7 @@ index fbfd094a938a96c03d614059fb1cd5a720865a83..8aaf12eb1b7c8fc996d2199d1182c04d
  
      private final ServerLevel world;
      private WorldBorder worldBorder;
-@@ -442,27 +443,61 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -443,27 +444,61 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean regenerateChunk(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk regenerate"); // Spigot

--- a/patches/server/0853-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0853-Replace-player-chunk-loader-system.patch
@@ -1930,10 +1930,10 @@ index 4c9832ccede082a468e97870b5f6b07bbed652f3..344c5bafe291a2542c4940e4d8023264
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 6f3dcd6bd19cbd9e4c1d65c17531863b451769de..09a64a9b002f0da20cbe19731068837be27d3480 100644
+index 3c13862e7ec96e7ee57c942bb2a7084f4553ae20..5e10a22c19ca1d5208dcfbe93436f5fdc3172c69 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2442,5 +2442,5 @@ public class ServerPlayer extends Player {
+@@ -2443,5 +2443,5 @@ public class ServerPlayer extends Player {
      }
      // CraftBukkit end
  
@@ -2041,7 +2041,7 @@ index 03824f73ecbac8ef6da586feb82f851557f82b6a..160c0f37aa3aaf7598f852acf9bd444f
  
              if ((i & 1) != 0) {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 5566dceb6b0434dbcc68ba443cb357463fe6e2d3..cd2640855485960bef12f8d3e04734058b0dc525 100644
+index 72b5d63127fbcd2913309f2c3c438b88728b4673..f667dafd44b6652788d3367cbbc76eef3bead23b 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -191,6 +191,43 @@ public class LevelChunk extends ChunkAccess {
@@ -2120,10 +2120,10 @@ index 5566dceb6b0434dbcc68ba443cb357463fe6e2d3..cd2640855485960bef12f8d3e0473405
  
      @Nullable
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 8aaf12eb1b7c8fc996d2199d1182c04d28306817..83b87f3a3372c71997b7614fe2102c8b1a841d15 100644
+index 7b5e099f73dae3846a1190523e769530ffac2f28..dc9a98d2aa894b2ff9b032d1d0707ad493bdca29 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2213,43 +2213,56 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2214,43 +2214,56 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      // Spigot start
      @Override
      public int getViewDistance() {

--- a/patches/server/0864-Fix-World-locateNearestStructure.patch
+++ b/patches/server/0864-Fix-World-locateNearestStructure.patch
@@ -45,10 +45,10 @@ index 344c5bafe291a2542c4940e4d80232644de7b877..00e6f60e13f50c727530de37ab9692ad
                  return pair != null ? (BlockPos) pair.getFirst() : null;
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 83b87f3a3372c71997b7614fe2102c8b1a841d15..b616f89a2f35bf79b0c9cc5b0470e7f5ca43263a 100644
+index dc9a98d2aa894b2ff9b032d1d0707ad493bdca29..85f2dfcd7f4ccba9c6a719c3fb66bbb9d5e9b0a7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2071,10 +2071,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2072,10 +2072,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      }
  

--- a/patches/server/0866-Fix-falling-block-spawn-methods.patch
+++ b/patches/server/0866-Fix-falling-block-spawn-methods.patch
@@ -21,10 +21,10 @@ index 850131e601047ab1c585a6f8883ac3c0d0e97ba1..99cb7625d50d5da4ce0999e10fb84403
              if (Snowball.class.isAssignableFrom(clazz)) {
                  entity = new net.minecraft.world.entity.projectile.Snowball(world, x, y, z);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b616f89a2f35bf79b0c9cc5b0470e7f5ca43263a..892c915aa6cecd91124358b13fa71fd066dc3f87 100644
+index 85f2dfcd7f4ccba9c6a719c3fb66bbb9d5e9b0a7..99c39f3271d0c3bfb0f854962b79a689cd560b9d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1422,7 +1422,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1423,7 +1423,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(material, "Material cannot be null");
          Validate.isTrue(material.isBlock(), "Material must be a block");
  
@@ -38,7 +38,7 @@ index b616f89a2f35bf79b0c9cc5b0470e7f5ca43263a..892c915aa6cecd91124358b13fa71fd0
          return (FallingBlock) entity.getBukkitEntity();
      }
  
-@@ -1431,7 +1436,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1432,7 +1437,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(location, "Location cannot be null");
          Validate.notNull(data, "BlockData cannot be null");
  

--- a/patches/server/0891-Pass-ServerLevel-for-gamerule-callbacks.patch
+++ b/patches/server/0891-Pass-ServerLevel-for-gamerule-callbacks.patch
@@ -158,10 +158,10 @@ index 798afc145c54306fcf0838d8daef2bdf17763da9..22feab6477bad023c2d6cc9ac99d392d
              this.onChanged(server);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 892c915aa6cecd91124358b13fa71fd066dc3f87..48825eaba9677a8b1e4fff80738e17d08e3307f8 100644
+index 99c39f3271d0c3bfb0f854962b79a689cd560b9d..b6770f6dbd88990151513c44259d926381983cff 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1926,7 +1926,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1927,7 +1927,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          // Paper end
          GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(CraftWorld.getGameRulesNMS().get(rule));
          handle.deserialize(event.getValue()); // Paper
@@ -170,7 +170,7 @@ index 892c915aa6cecd91124358b13fa71fd066dc3f87..48825eaba9677a8b1e4fff80738e17d0
          return true;
      }
  
-@@ -1966,7 +1966,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1967,7 +1967,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          // Paper end
          GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(CraftWorld.getGameRulesNMS().get(rule.getName()));
          handle.deserialize(event.getValue()); // Paper


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
218294b1 PR-743: Support setting individual Wither head targets

CraftBukkit Changes:
d48f2d1a PR-1047: Support setting individual Wither head targets
518f1bee SPIGOT-6948: Motion from Explosion after Respawn
f3c7a6ac SPIGOT-7019: Add yaw in World#getSpawnLocation